### PR TITLE
skip whitespace

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -39,7 +39,7 @@ describe('JSONSplitter', function() {
     const s = new JSONSplitter();
     s.write('[] {}""foo');
     assert.strictEqual(s.read(), '[]');
-    assert.strictEqual(s.read(), ' {}');
+    assert.strictEqual(s.read(), '{}');
     assert.strictEqual(s.read(), '""');
     assert.strictEqual(s.read(), null);
     s.end();
@@ -57,7 +57,7 @@ describe('JSONSplitter', function() {
     s.write(' {}{}');
     assert.deepStrictEqual(called, [2, 5, 7]);
     assert.deepStrictEqual(s.read(), '[]');
-    assert.deepStrictEqual(s.read(), ' {}');
+    assert.deepStrictEqual(s.read(), '{}');
     assert.deepStrictEqual(s.read(), '{}');
     assert.deepStrictEqual(s.read(), null);
   });


### PR DESCRIPTION
- Don't push out string with leading whitespace.
- Don't buffer leading whitespace.

Some applications such as CouchDB continous change
streams will send whitespace as a form of heartbeat
which can causing lots of whitespace being buffered
if not JSON data is received.
Essentially causing a memory leak over time.